### PR TITLE
Fix incorrect result by CheckSumGenerator for large files

### DIFF
--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
@@ -285,11 +285,25 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
             {
                 using HashAlgorithm? hashAlgo = CreateHashAlgorithm(inputHashingAlgorithm);
 
+                long fileSize = fileStream.Length;
+                int bufferSize;
+                if (fileSize > int.MaxValue)
+                {
+                    string message = LanguageManager.Instance.Common.UnableOpenFile;
+                    Exception exception = new FileLoadException(message);
+                    throw new FileLoadException(message);
+                }
+                else
+                {
+                    bufferSize = (int)fileSize;
+                }
+
                 byte[]? fileHash = await HashingHelper.ComputeHashAsync(
                         hashAlgo,
                         fileStream,
                         new Progress<HashingProgress>(UpdateProgress),
-                        _cancellationTokenSource.Token);
+                        _cancellationTokenSource.Token,
+                        bufferSize);
 
                 string? fileHashString = BitConverter
                     .ToString(fileHash)

--- a/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
+++ b/src/dev/impl/DevToys/ViewModels/Tools/Generators/CheckSumGenerator/CheckSumGeneratorToolViewModel.cs
@@ -286,16 +286,12 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
                 using HashAlgorithm? hashAlgo = CreateHashAlgorithm(inputHashingAlgorithm);
 
                 long fileSize = fileStream.Length;
-                int bufferSize;
+
                 if (fileSize > int.MaxValue)
                 {
                     string message = LanguageManager.Instance.Common.UnableOpenFile;
                     Exception exception = new FileLoadException(message);
                     throw new FileLoadException(message);
-                }
-                else
-                {
-                    bufferSize = (int)fileSize;
                 }
 
                 byte[]? fileHash = await HashingHelper.ComputeHashAsync(
@@ -303,7 +299,7 @@ namespace DevToys.ViewModels.Tools.CheckSumGenerator
                         fileStream,
                         new Progress<HashingProgress>(UpdateProgress),
                         _cancellationTokenSource.Token,
-                        bufferSize);
+                        (int)fileSize);
 
                 string? fileHashString = BitConverter
                     .ToString(fileHash)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

CheckSumGenerator returns an incorrect result if the file is larger than about 1MB.

Issue Number: N/A

## What is the new behavior?

- Allocate enough buffer size to calculate a checksum
- Throw FileLoadException with a message if an input file is larger than a size HashingHelper supports

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR, have you:

- [x] Followed the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Verified that the change work in Release build configuration
- [x] Checked all unit tests pass